### PR TITLE
Import correct pickle package based on if Python 2 or 3 is running

### DIFF
--- a/scripts/fix_https_fixtures.py
+++ b/scripts/fix_https_fixtures.py
@@ -1,10 +1,14 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
+from six import PY2, PY3
 
 import base64
 import urlparse
 import sqlalchemy as sqla
-import cPickle
+if PY2:
+    import cPickle
+if PY3:
+    import _pickle as cPickle
 import sys
 import re
 

--- a/vcr/sqlite_cassette.py
+++ b/vcr/sqlite_cassette.py
@@ -1,10 +1,15 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
+from six import PY2, PY3
+
 from . import cassette
 from .matchers import requests_match
 from .errors import UnhandledHTTPRequestError
 import sqlalchemy as sqla
-import cPickle
+if PY2:
+    import cPickle
+if PY3:
+    import _pickle as cPickle
 import base64
 import copy
 


### PR DESCRIPTION
@spulec `yipit_vcrpy` imports `cPickle`. In Python 3 this package is renamed to `_pickle`. I've added code to import the correct name depending on which version of Python is running. Thoughts? Note that it appears that work has already been done to make the rest of the package Python 2/3 compatible, as `six` is already used in other places, and the `print()` function is used.